### PR TITLE
Look up Open Tree Taxonomy and Open Tree induced subtree for provided phylorefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
       "plugin:vue/essential",
       "eslint:recommended"
     ],
-    "rules": {},
+    "rules": {
+      "no-console": "warn"
+    },
     "parserOptions": {
       "parser": "babel-eslint"
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bootstrap": "^4.2.1",
     "bootstrap-vue": "^2.0.0-rc.11",
     "filesaver.js-npm": "^1.0.1",
-    "jquery": "^3.3.1",
+    "jquery": ">=3.4.0",
     "lodash": "^4.17.11",
     "newick-js": "^1.1.0",
     "popper.js": "^1.14.6",

--- a/src/App.vue
+++ b/src/App.vue
@@ -243,7 +243,7 @@ export default {
             // Redo query without unknown OTT Ids.
             jQuery.ajax({
               type: 'POST',
-              url: 'https://ot39.opentreeoflife.org/v3/tree_of_life/induced_subtree',
+              url: 'https://api.opentreeoflife.org/v3/tree_of_life/induced_subtree',
               data: JSON.stringify({
                 ott_ids: knownOttIds,
               }),
@@ -272,8 +272,7 @@ export default {
         if(has(info, 'name') && info.name && has(info, 'matches') && info.matches && info.matches.length > 0) {
           const name = info.name.trim();
           // console.log("Setting", name, "to", info['matches']);
-          // Do we have any flags? If so, ignore this.
-          const flags = info.matches[0].taxon.flags || [];
+
           // TODO do something cleverer when choosing between multiple matches
           Vue.set(this.openTreeTaxonomyInfoByName, name, info['matches'] || []);
         }

--- a/src/App.vue
+++ b/src/App.vue
@@ -313,7 +313,7 @@ export default {
         .sort();
 
       // Step 1. Delete existing entries for the provided names.
-      this.setOpenTreeTaxonomyInfoByNames(names.map(name => {
+      setOpenTreeTaxonomyInfoByNames(names.map(name => {
         return {
           name,
           matches: [],
@@ -331,7 +331,7 @@ export default {
           contentType: 'application/json; charset=utf-8',
           dataType: 'json',
           success: (data) => {
-            this.setOpenTreeTaxonomyInfoByNames(data.results);
+            setOpenTreeTaxonomyInfoByNames(data.results);
           },
         })
           .fail(x => console.log("Error accessing Open Tree Taxonomy", x));

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,7 @@
         <div class="card-body p-0">
           <PhylorefTable
             :phylorefs="phylorefs"
-            :openTreeTaxonomyInfoByName="openTreeTaxonomyInfoByName"
+            :openTreeTaxonomyInfoBySpecifierLabel="openTreeTaxonomyInfoBySpecifierLabel"
           />
         </div>
         <div class="card-footer">
@@ -162,6 +162,23 @@ export default {
       const ottIds = this.allSpecifiers.map(specifier => this.getOpenTreeTaxonomyID(specifier))
         .filter(x => x !== undefined && x !== null);
       return ottIds;
+    },
+    openTreeTaxonomyInfoBySpecifierLabel() {
+      // Convert openTreeTaxonomyInfoByName into matches by specifier label.
+      const openTreeTaxonomyInfoBySpecifierLabel = {};
+      this.allSpecifiers.forEach(specifier => {
+        const specifierLabel = PhylorefWrapper.getSpecifierLabel(specifier);
+        if(!specifierLabel) return;
+
+        const sciname = this.getScinameForSpecifier(specifier);
+        if(!sciname) return;
+
+        const ottId = this.openTreeTaxonomyInfoByName[sciname];
+        if(!ottId) return;
+
+        openTreeTaxonomyInfoBySpecifierLabel[specifierLabel] = ottId;
+      });
+      return openTreeTaxonomyInfoBySpecifierLabel;
     },
     exampleJSONLDURLs() { return [
       // Returns a list of example files to display in the "Examples" menu.

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,7 @@
         class="card border-dark mt-2"
       >
         <h5 class="card-header">
-          Phylogeny
+          Phylogeny visualization
         </h5>
         <div class="card-body">
           <Phylotree
@@ -144,11 +144,6 @@ export default {
     phylorefs: [],
     newick: "()",
     openTreeTaxonomyInfoByName: {},
-    PHYX_CONTEXT_JSON: "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
-    ONTOLOGY_BASEURI: "http://example.org/#",
-    reasoningInProgress: false,
-    reasoningResults: {},
-    currentNodes: {},
   }},
   computed: {
     allSpecifiers() {

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -4,13 +4,14 @@
       <th width="15%">Name</th>
       <th width="40%">Description</th>
       <th>Specifiers</th>
+      <th>Open Tree Taxonomy ID</th>
     </thead>
     <tbody>
       <tr
         v-if="phylorefs.length === 0"
         class="bg-white"
       >
-        <td colspan="3">
+        <td colspan="4">
           <center><em>No phyloreferences loaded</em></center>
         </td>
       </tr>
@@ -26,6 +27,7 @@
             <td>
               <center><em>No specifiers provided.</em></center>
             </td>
+            <td>&nbsp;</td>
           </tr>
         </template>
         <template v-else>
@@ -43,121 +45,18 @@
                 {{getSpecifierType(phyloref, specifier)}}
                 <span v-html="getLabelForSpecifierAsHTML(specifier)"></span>
               </td>
+              <td>
+                <template v-if="getOpenTreeTaxonomyID(specifier)">
+                  <a target="_blank" :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)">{{getOpenTreeTaxonomyID(specifier)}}</a>
+                  (<a target="_blank" :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)">ott</a>)
+                </template>
+              </td>
             </tr>
-            <template v-for="(phyloref, phylorefIndex) of loadedPhylorefs">
-              <tr :key="phylorefIndex"><!-- This :key only works as long as users can't reorder the phylorefs -->
-                <td :rowspan="getSpecifiersForPhyloref(phyloref).length + 1">
-                  {{ phyloref.label || `Phyloref ${phylorefIndex + 1}` }}
-                </td>
-                <td :rowspan="getSpecifiersForPhyloref(phyloref).length + 1">
-                  <span v-html="getPhylorefDescription(phyloref)"></span>
-                </td>
-              </tr>
-              <template v-for="specifier of getSpecifiersForPhyloref(phyloref)">
-                <tr :key="'phyloref' + phylorefIndex + ', specifier: ' + getLabelForSpecifier(specifier)">
-                  <td>{{getSpecifierType(phyloref, specifier)}} <span v-html="getLabelForSpecifierAsHTML(specifier)"></span></td>
-                  <td>
-                    <template v-if="getOpenTreeTaxonomyID(specifier)">
-                      <a target="_blank" :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)">{{getOpenTreeTaxonomyID(specifier)}}</a>
-                      (<a target="_blank" :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)">ott</a>)
-                    </template>
-                  </td>
-                </tr>
-              </template>
-            </template>
-          </tbody>
-        </table>
-      </div>
-      <div class="card-footer">
-        <div class="btn-group" role="group" area-label="Add phyloreferences">
-          <button
-            class="btn btn-primary"
-            href="javascript:;"
-            onclick="$('#load-jsonld').trigger('click')"
-          >
-            Add phyloreferences from JSON-LD file
-          </button>
-          <input
-            id="load-jsonld"
-            type="file"
-            multiple="true"
-            class="d-none"
-            @change="loadJSONLDFromFileInputById('#load-jsonld')"
-          >
-          <button class="btn btn-secondary dropdown-toggle" type="button" id="addFromExamples" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Add phyloreferences from example
-          </button>
-          <div class="dropdown-menu" aria-labelledby="addFromExamples">
-            <a href="javascript:;" class="dropdown-item" v-for="example of exampleJSONLDURLs" v-bind:key="example.url" @click="loadJSONLDFromURL(example.url)">
-              {{example.title}}
-            </a>
-          </div>
-        </div>
-        <div class="btn-group ml-2" role="group" area-label="Edit phyloreference list">
-          <button class="btn btn-danger" type="button" @click="loadedPhylorefs = []">
-            Clear phylorefs
-          </button>
-        </div>
-        <div class="btn-group ml-2" role="group" area-label="Open Tree Taxonomy tasks">
-          <button class="btn btn-primary" type="button" @click="queryOpenTreeTaxonomyIDs()">
-            Query specifiers against Open Tree of Life Taxonomy
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <div class="card border-dark mt-2">
-      <h5 class="card-header border-dark">
-        Phylogeny
-      </h5>
-      <div class="card-body">
-        <form>
-          <div class="form-group row">
-            <label
-              for="newick"
-              class="col-md-2 control-label"
-            >
-              Newick
-            </label>
-            <div class="col-md-10 input-group">
-              <textarea
-                v-model.lazy="newick"
-                rows="3"
-                class="form-control"
-                placeholder="Enter Newick string for phylogeny here"
-              />
-            </div>
-          </div>
-        </form>
-      </div>
-      <div class="card-footer">
-        <div class="btn-group" role="group" area-label="Look up trees on the Open Tree of Life">
-          <button
-            class="btn btn-primary"
-            href="javascript:;"
-            :click="downloadInducedSubtreeFromOpenTreeOfLife(ottIdsForAllSpecifiers)"
-          >
-            Download induced subtree from the Open Tree of Life
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- Display the phylogeny (unless there were Newick parsing errors) -->
-    <div
-      class="card border-dark mt-2"
-    >
-      <h5 class="card-header">
-        Phylogeny
-      </h5>
-      <div class="card-body">
-        <Phylotree
-          :newick="newick"
-        />
-      </div>
-    </div>
-
-  </div>
+          </template>
+        </template>
+      </template>
+    </tbody>
+  </table>
 </template>
 
 <script>
@@ -179,51 +78,12 @@ export default {
   props: {
     phylorefs: {
       type: Array,
-      default: () => { return []; }
+      default: () => { return []; },
     },
-  },
-  data: function () {
-    // Local variables for this component.
-    return {
-      flagDisplayExpression: false,
-      loadedPhylorefs: [],
-      openTreeTaxonomyInfoByName: {},
-      newick: '()',
-      PHYX_CONTEXT_JSON: "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
-      ONTOLOGY_BASEURI: "http://example.org/#",
-      reasoningInProgress: false,
-      reasoningResults: {},
-      currentNodes: {}
-    };
-  },
-  computed: {
-    allSpecifiers() {
-      return this.loadedPhylorefs.map(phyloref => this.getSpecifiersForPhyloref(phyloref)).reduce((acc, val) => acc.concat(val), []);
+    openTreeTaxonomyInfoByName: {
+      type: Object,
+      default: () => { return {}; },
     },
-    phylorefsWithMoreThanOneSpecifier() {
-      return this.loadedPhylorefs.filter(phyloref => (this.getSpecifiersForPhyloref(phyloref) || []).length > 1);
-    },
-    ottIdsForAllSpecifiers() {
-      // Assumes that queryOpenTreeTaxonomyIDs has already been called!
-      const ottIds = this.allSpecifiers.map(specifier => this.getOpenTreeTaxonomyID(specifier))
-        .filter(x => x !== undefined && x !== null);
-      return ottIds;
-    },
-    exampleJSONLDURLs() { return [
-      // Returns a list of example files to display in the "Examples" menu.
-      {
-        url: 'examples/fisher_et_al_2007.jsonld',
-        title: 'Fisher et al, 2007',
-      },
-      {
-        url: 'examples/hillis_and_wilcox_2005.jsonld',
-        title: 'Hillis and Wilcox, 2005',
-      },
-      {
-        url: 'examples/brochu_2003.jsonld',
-        title: 'Brochu 2003',
-      },
-    ]}
   },
   methods: {
     /*
@@ -245,62 +105,6 @@ export default {
       if(matches && matches.length > 0) {
         return matches[0]['taxon']['ott_id'];
       }
-    },
-
-    queryOpenTreeTaxonomyIDs() {
-      // Calculate names from currently loaded specifiers.
-      const names = this.allSpecifiers.map(specifier => this.getScinameForSpecifier(specifier));
-      this.queryOpenTreeTaxonomyIDsForNames({names});
-    },
-
-    setOpenTreeTaxonomyInfoByNames(results) {
-      results.forEach(info => {
-        if(has(info, 'name') && info.name && has(info, 'matches') && info.matches && info.matches.length > 0) {
-          const name = info.name.trim();
-          // console.log("Setting", name, "to", info['matches']);
-          // Do we have any flags? If so, ignore this.
-          const flags = info.matches[0].taxon.flags || [];
-          // TODO do something cleverer when choosing between multiple matches
-          Vue.set(this.openTreeTaxonomyInfoByName, name, info['matches'] || []);
-        }
-      });
-    },
-
-    queryOpenTreeTaxonomyIDsForNames(options) {
-      // Creates queries to the Open Tree Taxonomy for the provided names.
-      // This will return asynchonously; you need to call getOpenTreeTaxonomyID(name)
-      // to retrieve the results.
-      // Options can be anything from https://github.com/OpenTreeOfLife/germinator/wiki/TNRS-API-v3#match_names, including:
-      //  - context_name:
-      //  - do_approximate_matching
-      // Deduplicate names to be queried.
-      const names = uniq(options.names)
-        .filter(name => name !== undefined && name !== null) // Eliminate any undefineds or nulls.
-        .sort();
-      // Step 1. Delete existing entries for the provided names.
-      this.setOpenTreeTaxonomyInfoByNames(names.map(name => {
-        return {
-          name,
-          matches: [],
-        };
-      }));
-      // OToL TNRS match_names has a limit of 1,000 names.
-      chunk(names, 999).forEach(chunk => {
-        options.names = chunk;
-        const data = JSON.stringify(options);
-        // Step 2. Spawn queries to OTT asking for the names.
-        jQuery.ajax({
-          type: 'POST',
-          url: 'https://api.opentreeoflife.org/v3/tnrs/match_names',
-          data,
-          contentType: 'application/json; charset=utf-8',
-          dataType: 'json',
-          success: (data) => {
-            this.setOpenTreeTaxonomyInfoByNames(data.results);
-          },
-        })
-          .fail(x => console.log("Error accessing Open Tree Taxonomy", x));
-      });
     },
 
     getSpecifierType(phyloref, specifier) {

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -32,7 +32,7 @@
         </template>
         <template v-else>
           <template v-for="(specifier, specifierIndex) of getSpecifiersForPhyloref(phyloref)">
-            <tr  :key="'phyloref_' + phylorefIndex + '_specifier_' + specifierIndex">
+            <tr :key="'phyloref_' + phylorefIndex + '_specifier_' + specifierIndex">
               <template v-if="specifierIndex === 0">
                 <td :rowspan="getSpecifiersForPhyloref(phyloref).length">
                   {{ phyloref.label || `Phyloref ${phylorefIndex + 1}` }}
@@ -74,16 +74,10 @@
  *  - Open Tree Taxonomy ID
  */
 
-import { has } from 'lodash';
 import { PhylorefWrapper } from '@phyloref/phyx';
-
-import Phylotree from './phylogeny/Phylotree.vue';
 
 export default {
   name: 'PhylorefTable',
-  components: {
-    Phylotree,
-  },
   props: {
     phylorefs: {
       type: Array,

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -44,57 +44,135 @@
                 <span v-html="getLabelForSpecifierAsHTML(specifier)"></span>
               </td>
             </tr>
-            <template v-for="specifier of getSpecifiersForPhyloref(phyloref)">
-              <tr :key="'phyloref' + phylorefIndex + ', specifier: ' + getLabelForSpecifier(specifier)">
-                <td>{{getSpecifierType(phyloref, specifier)}} <span v-html="getLabelForSpecifierAsHTML(specifier)"></span></td>
-                <td>
-                  <template v-if="getOpenTreeTaxonomyID(specifier)">
-                    <a target="_blank" :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)">{{getOpenTreeTaxonomyID(specifier)}}</a>
-                    (<a target="_blank" :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)">ott</a>)
-                  </template>
+            <template v-for="(phyloref, phylorefIndex) of loadedPhylorefs">
+              <tr :key="phylorefIndex"><!-- This :key only works as long as users can't reorder the phylorefs -->
+                <td :rowspan="getSpecifiersForPhyloref(phyloref).length + 1">
+                  {{ phyloref.label || `Phyloref ${phylorefIndex + 1}` }}
+                </td>
+                <td :rowspan="getSpecifiersForPhyloref(phyloref).length + 1">
+                  <span v-html="getPhylorefDescription(phyloref)"></span>
                 </td>
               </tr>
+              <template v-for="specifier of getSpecifiersForPhyloref(phyloref)">
+                <tr :key="'phyloref' + phylorefIndex + ', specifier: ' + getLabelForSpecifier(specifier)">
+                  <td>{{getSpecifierType(phyloref, specifier)}} <span v-html="getLabelForSpecifierAsHTML(specifier)"></span></td>
+                  <td>
+                    <template v-if="getOpenTreeTaxonomyID(specifier)">
+                      <a target="_blank" :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)">{{getOpenTreeTaxonomyID(specifier)}}</a>
+                      (<a target="_blank" :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)">ott</a>)
+                    </template>
+                  </td>
+                </tr>
+              </template>
             </template>
-          </template>
-        </tbody>
-      </table>
-    </div>
-    <div class="card-footer">
-      <div class="btn-group" role="group" area-label="Add phyloreferences">
-        <button
-          class="btn btn-primary"
-          href="javascript:;"
-          onclick="$('#load-jsonld').trigger('click')"
-        >
-          Add phyloreferences from JSON-LD file
-        </button>
-        <input
-          id="load-jsonld"
-          type="file"
-          multiple="true"
-          class="d-none"
-          @change="loadJSONLDFromFileInputById('#load-jsonld')"
-        >
-        <button class="btn btn-secondary dropdown-toggle" type="button" id="addFromExamples" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Add phyloreferences from example
-        </button>
-        <div class="dropdown-menu" aria-labelledby="addFromExamples">
-          <a href="javascript:;" class="dropdown-item" v-for="example of exampleJSONLDURLs" v-bind:key="example.url" @click="loadJSONLDFromURL(example.url)">
-            {{example.title}}
-          </a>
+          </tbody>
+        </table>
+      </div>
+      <div class="card-footer">
+        <div class="btn-group" role="group" area-label="Add phyloreferences">
+          <button
+            class="btn btn-primary"
+            href="javascript:;"
+            onclick="$('#load-jsonld').trigger('click')"
+          >
+            Add phyloreferences from JSON-LD file
+          </button>
+          <input
+            id="load-jsonld"
+            type="file"
+            multiple="true"
+            class="d-none"
+            @change="loadJSONLDFromFileInputById('#load-jsonld')"
+          >
+          <button class="btn btn-secondary dropdown-toggle" type="button" id="addFromExamples" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Add phyloreferences from example
+          </button>
+          <div class="dropdown-menu" aria-labelledby="addFromExamples">
+            <a href="javascript:;" class="dropdown-item" v-for="example of exampleJSONLDURLs" v-bind:key="example.url" @click="loadJSONLDFromURL(example.url)">
+              {{example.title}}
+            </a>
+          </div>
+        </div>
+        <div class="btn-group ml-2" role="group" area-label="Edit phyloreference list">
+          <button class="btn btn-danger" type="button" @click="loadedPhylorefs = []">
+            Clear phylorefs
+          </button>
+        </div>
+        <div class="btn-group ml-2" role="group" area-label="Open Tree Taxonomy tasks">
+          <button class="btn btn-primary" type="button" @click="queryOpenTreeTaxonomyIDs()">
+            Query specifiers against Open Tree of Life Taxonomy
+          </button>
         </div>
       </div>
-      <div class="btn-group ml-2" role="group" area-label="Edit phyloreference list">
-        <button class="btn btn-danger" type="button" @click="loadedPhylorefs = []">
-          Clear phylorefs
-        </button>
+    </div>
+
+    <div class="card border-dark mt-2">
+      <h5 class="card-header border-dark">
+        Phylogeny
+      </h5>
+      <div class="card-body">
+        <form>
+          <div class="form-group row">
+            <label
+              for="newick"
+              class="col-md-2 control-label"
+            >
+              Newick
+            </label>
+            <div class="col-md-10 input-group">
+              <textarea
+                v-model.lazy="newick"
+                rows="3"
+                class="form-control"
+                placeholder="Enter Newick string for phylogeny here"
+              />
+            </div>
+          </div>
+        </form>
       </div>
-      <div class="btn-group ml-2" role="group" area-label="Open Tree Taxonomy tasks">
-        <button class="btn btn-primary" type="button" @click="queryOpenTreeTaxonomyIDs()">
-          Query specifiers against Open Tree of Life Taxonomy
-        </button>
+      <div class="card-footer">
+        <div class="btn-group" role="group" area-label="Look up trees on the Open Tree of Life">
+          <button
+            class="btn btn-primary"
+            href="javascript:;"
+            :click="downloadInducedSubtreeFromOpenTreeOfLife(ottIdsForAllSpecifiers)"
+          >
+            Download induced subtree from the Open Tree of Life
+          </button>
+        </div>
       </div>
     </div>
+
+    <!-- Display the list of errors encountered when parsing this Newick string -->
+    <div
+      v-if="phylogenyNewickErrors.length !== 0"
+      class="card border-dark mt-2"
+    >
+      <h5 class="card-header bg-danger">
+        Errors occurred while parsing Newick string
+      </h5>
+      <div class="card-body">
+        <template v-for="(error, errorIndex) of phylogenyNewickErrors">
+          <p><strong>{{ error.title }}.</strong> {{ error.message }}</p>
+        </template>
+      </div>
+    </div>
+
+    <!-- Display the phylogeny (unless there were Newick parsing errors) -->
+    <div
+      v-if="phylogenyNewickErrors.length === 0"
+      class="card border-dark mt-2"
+    >
+      <h5 class="card-header">
+        Phylogeny visualization
+      </h5>
+      <div class="card-body">
+        <Phylotree
+          :newick="newick"
+        />
+      </div>
+    </div>
+
   </div>
 </template>
 
@@ -111,11 +189,59 @@ import { PhylorefWrapper } from '@phyloref/phyx';
 
 export default {
   name: 'PhylorefTable',
+  components: {
+    Phylotree,
+  },
   props: {
     phylorefs: {
       type: Array,
       default: () => { return []; }
     },
+  },
+  data: function () {
+    // Local variables for this component.
+    return {
+      flagDisplayExpression: false,
+      loadedPhylorefs: [],
+      openTreeTaxonomyInfoByName: {},
+      newick: '()',
+    };
+  },
+  computed: {
+    allSpecifiers() {
+      return this.loadedPhylorefs.map(phyloref => this.getSpecifiersForPhyloref(phyloref)).reduce((acc, val) => acc.concat(val), []);
+    },
+    phylorefsWithMoreThanOneSpecifier() {
+      return this.loadedPhylorefs.filter(phyloref => (this.getSpecifiersForPhyloref(phyloref) || []).length > 1);
+    },
+    ottIdsForAllSpecifiers() {
+      // Assumes that queryOpenTreeTaxonomyIDs has already been called!
+      const ottIds = this.allSpecifiers.map(specifier => this.getOpenTreeTaxonomyID(specifier))
+        .filter(x => x !== undefined && x !== null);
+      return ottIds;
+    },
+    phylogenyNewickErrors() {
+      const errors = PhylogenyWrapper.getErrorsInNewickString(this.newick);
+
+      // For historical reason, we consider an empty Newick string as an error.
+      // We should not do this.
+      return errors.filter(error => error.title !== 'No phylogeny entered');
+    },
+    exampleJSONLDURLs() { return [
+      // Returns a list of example files to display in the "Examples" menu.
+      {
+        url: 'examples/fisher_et_al_2007.jsonld',
+        title: 'Fisher et al, 2007',
+      },
+      {
+        url: 'examples/hillis_and_wilcox_2005.jsonld',
+        title: 'Hillis and Wilcox, 2005',
+      },
+      {
+        url: 'examples/brochu_2003.jsonld',
+        title: 'Brochu 2003',
+      },
+    ]}
   },
   methods: {
     /*

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -47,8 +47,14 @@
               </td>
               <td>
                 <template v-if="getOpenTreeTaxonomyID(specifier)">
-                  <a target="_blank" :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)">{{getOpenTreeTaxonomyID(specifier)}}</a>
-                  (<a target="_blank" :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)">ott</a>)
+                  <a
+                    target="_blank"
+                    :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)"
+                  >{{getOpenTreeTaxonomyID(specifier)}}</a>
+                  (<a
+                    target="_blank"
+                    :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)"
+                  >ott</a>)
                 </template>
               </td>
             </tr>
@@ -61,14 +67,17 @@
 
 <script>
 /*
- * A table for displaying information about loaded phyloreferences. Specifically,
- * this includes:
- *  - Phyloreference name
+ * A table for displaying information about phyloreferences. It displays the following information:
+ *  - Phyloref label
  *  - Clade definition
- *  - List of specifiers
+ *  - Specifier
+ *  - Open Tree Taxonomy ID
  */
 
+import { has } from 'lodash';
 import { PhylorefWrapper } from '@phyloref/phyx';
+
+import Phylotree from './phylogeny/Phylotree.vue';
 
 export default {
   name: 'PhylorefTable',

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -105,7 +105,9 @@ export default {
 
     getOpenTreeTaxonomyID(specifier) {
       // Returns the Open Tree Taxonomy ID for a particular specifier.
-      const matches = this.openTreeTaxonomyInfoBySpecifierLabel[this.getLabelForSpecifier(specifier)];
+      const matches = this.openTreeTaxonomyInfoBySpecifierLabel[
+        PhylorefWrapper.getSpecifierLabel(specifier)
+      ];
       if(matches && matches.length > 0) {
         return matches[0]['taxon']['ott_id'];
       }

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -80,7 +80,7 @@ export default {
       type: Array,
       default: () => { return []; },
     },
-    openTreeTaxonomyInfoByName: {
+    openTreeTaxonomyInfoBySpecifierLabel: {
       type: Object,
       default: () => { return {}; },
     },
@@ -101,7 +101,8 @@ export default {
     },
 
     getOpenTreeTaxonomyID(specifier) {
-      const matches = this.openTreeTaxonomyInfoByName[this.getScinameForSpecifier(specifier)];
+      // Returns the Open Tree Taxonomy ID for a particular specifier.
+      const matches = this.openTreeTaxonomyInfoBySpecifierLabel[this.getLabelForSpecifier(specifier)];
       if(matches && matches.length > 0) {
         return matches[0]['taxon']['ott_id'];
       }

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -205,6 +205,11 @@ export default {
       loadedPhylorefs: [],
       openTreeTaxonomyInfoByName: {},
       newick: '()',
+      PHYX_CONTEXT_JSON: "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+      ONTOLOGY_BASEURI: "http://example.org/#",
+      reasoningInProgress: false,
+      reasoningResults: {},
+      currentNodes: {}
     };
   },
   computed: {

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -46,14 +46,14 @@
                 <span v-html="getLabelForSpecifierAsHTML(specifier)"></span>
               </td>
               <td>
-                <template v-if="getOpenTreeTaxonomyID(specifier)">
+                <template v-if="getOTTId(specifier)">
                   <a
                     target="_blank"
-                    :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOpenTreeTaxonomyID(specifier)"
-                  >{{getOpenTreeTaxonomyID(specifier)}}</a>
+                    :href="'https://tree.opentreeoflife.org/opentree/@ott' + getOTTId(specifier)"
+                  >{{getOTTId(specifier)}}</a>
                   (<a
                     target="_blank"
-                    :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOpenTreeTaxonomyID(specifier)"
+                    :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOTTId(specifier)"
                   >ott</a>)
                 </template>
               </td>
@@ -83,7 +83,7 @@ export default {
       type: Array,
       default: () => { return []; },
     },
-    openTreeTaxonomyInfoBySpecifierLabel: {
+    ottInfoBySpecifierLabel: {
       type: Object,
       default: () => { return {}; },
     },
@@ -103,9 +103,9 @@ export default {
       return description.replace(/\n+/g, "<br />");
     },
 
-    getOpenTreeTaxonomyID(specifier) {
+    getOTTId(specifier) {
       // Returns the Open Tree Taxonomy ID for a particular specifier.
-      const matches = this.openTreeTaxonomyInfoBySpecifierLabel[
+      const matches = this.ottInfoBySpecifierLabel[
         PhylorefWrapper.getSpecifierLabel(specifier)
       ];
       if(matches && matches.length > 0) {

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -143,28 +143,12 @@
       </div>
     </div>
 
-    <!-- Display the list of errors encountered when parsing this Newick string -->
-    <div
-      v-if="phylogenyNewickErrors.length !== 0"
-      class="card border-dark mt-2"
-    >
-      <h5 class="card-header bg-danger">
-        Errors occurred while parsing Newick string
-      </h5>
-      <div class="card-body">
-        <template v-for="(error, errorIndex) of phylogenyNewickErrors">
-          <p><strong>{{ error.title }}.</strong> {{ error.message }}</p>
-        </template>
-      </div>
-    </div>
-
     <!-- Display the phylogeny (unless there were Newick parsing errors) -->
     <div
-      v-if="phylogenyNewickErrors.length === 0"
       class="card border-dark mt-2"
     >
       <h5 class="card-header">
-        Phylogeny visualization
+        Phylogeny
       </h5>
       <div class="card-body">
         <Phylotree
@@ -224,13 +208,6 @@ export default {
       const ottIds = this.allSpecifiers.map(specifier => this.getOpenTreeTaxonomyID(specifier))
         .filter(x => x !== undefined && x !== null);
       return ottIds;
-    },
-    phylogenyNewickErrors() {
-      const errors = PhylogenyWrapper.getErrorsInNewickString(this.newick);
-
-      // For historical reason, we consider an empty Newick string as an error.
-      // We should not do this.
-      return errors.filter(error => error.title !== 'No phylogeny entered');
     },
     exampleJSONLDURLs() { return [
       // Returns a list of example files to display in the "Examples" menu.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -1,0 +1,519 @@
+<template>
+  <div>
+    <template v-if="newickErrors">
+      <p>
+        <strong>Error parsing phylogeny.</strong>
+        Please
+        <a
+          href="javascript: void"
+          @click="$store.commit('changeDisplay', {phylogeny})"
+        >
+          edit the phylogeny
+        </a>
+        to fix this error.
+      </p>
+    </template>
+    <div
+      v-else
+      class="phylotreeContainer"
+    >
+      <svg
+        :id="'phylogeny' + phylogenyIndex"
+        class="col-md-12 phylogeny"
+      />
+      <ResizeObserver @notify="redrawTree()" />
+    </div>
+  </div>
+</template>
+
+<script>
+/*
+ * This component can be used to insert a phylogeny. It includes code for highlighing
+ * the expecting and reasoned clade for a particular phyloreference.
+ */
+
+import { uniqueId, has } from 'lodash';
+import { PhylogenyWrapper } from '@phyloref/phyx';
+
+/*
+ * Note that this requires the Phylotree Javascript to be loaded in the HTML
+ * header: I haven't figured out how to include phylotree.js from within Vue CLI yet.
+ */
+
+export default {
+  name: 'Phylotree',
+  props: {
+    phylogeny: Object, // The phylogeny to render.
+    phyloref: Object, // The phyloreference to highlight.
+    spacingX: { // Spacing in the X axis in pixels.
+      type: Number,
+      default: 20,
+    },
+    phylogenyIndex: { // An index number of the phylogeny. Will be used to set up HTML DOM IDs.
+      type: String,
+      default: uniqueId(),
+    },
+  },
+  data() {
+    return {
+      // List of pinning nodes to highlight for a particular phylogeny.
+      pinningNodes: [],
+      // List of pinning nodes and all their children, so the entire clade can be
+      // highlighted as needed.
+      pinningNodeChildrenIRIs: new Set(),
+    };
+  },
+  computed: {
+    reasoningResults() {
+      // Included so we can watch this for changes, see `watch` below.
+      return this.$store.state.phyx.reasoningResults;
+    },
+    newickAsString() {
+      // Returns the Newick string of this phylogeny.
+      return this.phylogeny.newick || '()';
+    },
+    parsedNewick() {
+      return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
+        this.$store.getters.getBaseURIForPhylogeny(this.phylogeny),
+        d3.layout.newick_parser,
+      );
+    },
+    newickErrors() {
+      // Check to see if the newick could actually be parsed.
+      if (!has(this.parsedNewick, 'json') || this.parsedNewick.json === null) {
+        return (has(this.parsedNewick, 'error') ? this.parsedNewick.error : 'unknown error');
+      }
+      return undefined;
+    },
+    tree() {
+      // Set up Phylotree.
+      const tree = d3.layout.phylotree()
+        .svg(d3.select(`#phylogeny${this.phylogenyIndex}`))
+        .options({
+          'internal-names': true,
+          transitions: false,
+          'left-right-spacing': 'fit-to-size',
+          'top-bottom-spacing': 'fixed-step',
+        })
+        .style_nodes((element, data) => {
+          // Instructions used to style nodes in Phylotree
+          // - element: The D3 element of the node being styled
+          // - data: The data associated with the node being styled
+
+          // Make sure we don't already have an internal label node on this SVG node!
+          let textLabel = element.selectAll('text');
+
+          if (has(data, 'name') && data.name !== '' && data.children) {
+            // If the node has a label and has children (i.e. is an internal node),
+            // we display it next to the node by creating a new 'text' element.
+            if (textLabel.empty()) {
+              textLabel = element.append('text');
+
+              // Place internal label to the left of the root node.
+              textLabel.classed('internal-label', true)
+                .text(data.name)
+                .attr('dx', '.3em')
+                .attr('dy', '.3em');
+            }
+
+            // If the internal label has the same label as the currently
+            // selected phyloreference, add an 'id' so we can jump to it
+            // and a CSS class to render it differently from other labels.
+            if (
+              this.$store.getters.getExpectedNodeLabelsOnPhylogeny(this.phylogeny, this.phyloref).includes(data.name)
+            ) {
+              textLabel.attr('id', `current_expected_label_phylogeny_${this.phylogenyIndex}`);
+              textLabel.classed('selected-internal-label', true);
+            } else {
+              textLabel.attr('id', '');
+              textLabel.classed('selected-internal-label', false);
+            }
+          }
+
+          // If the internal label has the same IRI as the currently selected
+          // phyloreference's reasoned node, further mark it as the resolved node.
+          //
+          // Note that this node might NOT be labeled, in which case we need to
+          // label it now!
+          if (
+            this.phyloref !== undefined && has(data, '@id')
+            && this.$store.getters.getResolvedNodesForPhylogeny(this.phylogeny, this.phyloref).includes(data['@id'])
+          ) {
+            // We found another pinning node!
+            this.pinningNodes.push(data);
+            this.recurseNodes(data, node => this.pinningNodeChildrenIRIs.add(node['@id']));
+
+            // Mark this node as the pinning node.
+            element.classed('pinning-node', true);
+
+            // Make the pinning node circle larger (twice its usual size of 3).
+            element.select('circle').attr('r', 6);
+
+            // Set its id to 'current_pinning_node_phylogeny{{phylogenyIndex}}'
+            element.attr('id', `current_pinning_node_phylogeny_${this.phylogenyIndex}`);
+          }
+
+          // Maybe this isn't a pinning node, but it is a child of a pinning node.
+          if (
+            has(data, '@id')
+            && this.pinningNodeChildrenIRIs.has(data['@id'])
+          ) {
+            // Apply a class.
+            // Note that this applies to the resolved-node too.
+            element.classed('descendant-of-pinning-node-node', true);
+          }
+
+          if (data.name !== undefined && data.children === undefined) {
+            // Labeled leaf node! Look for taxonomic units.
+            const tunits = this.$store.getters
+              .getTaxonomicUnitsForNodeLabel(this.phylogeny, data.name);
+
+            if (tunits.length === 0) {
+              element.classed('terminal-node-without-tunits', true);
+            } else if (this.phyloref !== undefined) {
+              // If this is a terminal node, we should set its ID to
+              // `current_expected_label_phylogeny${phylogenyIndex}` if it is
+              // the currently expected node label.
+              if (
+                has(this.phyloref, 'label')
+                && this.$store.getters
+                  .getExpectedNodeLabelsOnPhylogeny(this.phylogeny, this.phyloref)
+                  .includes(data.name)
+              ) {
+                textLabel.attr('id', `current_expected_label_phylogeny_${this.phylogenyIndex}`);
+              }
+
+              // We should highlight internal specifiers.
+              if (has(this.phyloref, 'internalSpecifiers')) {
+                if (this.phyloref.internalSpecifiers
+                  .some(specifier => this.$store.getters
+                    .getNodeLabelsMatchedBySpecifier(this.phylogeny, specifier)
+                    .includes(data.name))
+                ) {
+                  element.classed('internal-specifier-node', true);
+                }
+              }
+
+              // We should highlight external specifiers.
+              if (has(this.phyloref, 'externalSpecifiers')) {
+                if (this.phyloref.externalSpecifiers
+                  .some(specifier => this.$store.getters
+                    .getNodeLabelsMatchedBySpecifier(this.phylogeny, specifier)
+                    .includes(data.name))
+                ) {
+                  element.classed('external-specifier-node', true);
+                }
+              }
+            }
+          }
+        })
+        .style_edges((element, data) => {
+          // Is the parent a descendant of a pinning node? If so, we need to
+          // select this branch!
+          if (
+            has(data, 'source')
+            && has(data.source, '@id')
+            && this.pinningNodeChildrenIRIs.has(data.source['@id'])
+          ) {
+            // Apply a class to this branch.
+            element.classed('descendant-of-pinning-node-branch', true);
+          } else {
+            element.classed('descendant-of-pinning-node-branch', false);
+          }
+        });
+      tree(this.parsedNewick);
+      return tree;
+    },
+  },
+  watch: {
+    phyloref() {
+      // We need to redraw the tree when phyloref changes.
+      this.redrawTree();
+    },
+    reasoningResults() {
+      // If reasoning occurs, we'll need to redraw this tree.
+      this.redrawTree();
+    },
+    phylogeny() {
+      // If the phylogeny changed, redraw the tree.
+      this.redrawTree();
+    },
+  },
+  mounted() {
+    // Redraw the tree when this component is loaded for the first time.
+    this.redrawTree();
+  },
+  methods: {
+    recurseNodes(node, func, nodeCount = 0, parentCount = undefined) {
+      // Recurse through PhyloTree nodes, executing function on each node.
+      //  - node: The node to recurse from. The function will be called on node
+      //          *before* being called on its children.
+      //  - func: The function to call on `node` and all of its children.
+      //  - nodeCount: `node` will be called with this nodeCount. All of its
+      //          children will be called with consecutively increasing nodeCounts.
+      //  - parentCount: The nodeCount associated with the parent of this node
+      //          within this run of recurseNodes. For instance, immediate children
+      //          of `node` will have a parentCount of 0. By default, `node` itself
+      //          will have a parentCount of `undefined`.
+      // When the function `func` is called, it is given three arguments:
+      //  - The current node object (initially: `node`)
+      //  - The count of the current node object (initially: `nodeCount`)
+      //  - The parent count of the current node object (initially: `parentCount`)
+      func(node, nodeCount, parentCount);
+
+      let nextID = nodeCount + 1;
+
+      // Recurse through all children of this node.
+      if (has(node, 'children')) {
+        node.children.forEach((child) => {
+          nextID = this.recurseNodes(
+            child,
+            func,
+            nextID,
+            nodeCount,
+          );
+        });
+      }
+
+      return nextID;
+    },
+    redrawTree() {
+      // Reset the pinning node information before redrawing.
+      this.pinningNodes = [];
+      this.pinningNodeChildrenIRIs = new Set();
+
+      // Draw the tree.
+      this.tree
+        .size([
+          // height
+          0,
+          // width
+          $(`#phylogeny${this.phylogenyIndex}`).width() - 40,
+          // We need more space because our fonts are bigger than the default.
+        ])
+        .spacing_x(this.spacingX)
+        .update();
+    },
+  },
+};
+</script>
+
+<style>
+.phylogeny {
+  width: 100%;
+}
+.phylotreeContainer {
+  /* Required for Vue-Resize to track its size */
+  position: relative;
+}
+
+/*
+ * Classes for phylogeny SVG elements
+ */
+
+/*
+ * Phylotree .node refers to the SVG groups that contain both the
+ * node itself as well as the text label next to it. This is confusing,
+ * but we will try to use that consistently below: *-node refers to the group
+ * that includes both the node as well as the label with it, while *-label
+ * refers only to the labels next to the nodes.
+ */
+.node {
+  /* Phylotree's CSS sets this to 10px; we prefer larger node labels */
+  font-size: 11pt;
+}
+
+/* Labels for internal nodes, whether phylorefs or not */
+.internal-label {
+  font-family: serif;
+  font-size: 16pt;
+  font-style: italic;
+
+  text-anchor: start; /* Align text so it starts at the coordinates provided */
+}
+
+/* Node label for an internal specifier */
+.internal-specifier-node text {
+    font-weight: bolder;
+    fill: rgb(0, 24, 168) !important;
+}
+
+/* Node label for an external specifier */
+.external-specifier-node text {
+    font-weight: bolder;
+    fill: rgb(0, 24, 168) !important;
+}
+
+/* Node label for a terminal node without taxonomic units */
+.terminal-node-without-tunits {
+}
+
+/* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
+.selected-internal-label {
+    font-size: 16pt;
+    fill: rgb(0, 24, 168);
+}
+
+/*
+ * An additional class for nodes that are the pinning node. When the phyloreference
+ * resolves to a single terminal node, it will be laid out in this way, rather
+ * than as an .internal-specifier-node.
+ */
+.pinning-node text {
+    font-weight: bolder;
+}
+
+/*
+ * The descendant-of-pinning-node class instructions below apply to the entire resolved node,
+ * which includes the circle as well as the text label. We want to coordinate
+ * colours between:
+ *  - The circle that appears next to the node label,
+ *  - The node label, whether internal or terminal, and
+ *  - The branches descending from the pinning node.
+ *
+ * Note that .internal-specifier-node is set up to override this formatting, so
+ * internal node labels will be formatted differently from other terminals
+ * descending from the pinning node.
+ */
+.descendant-of-pinning-node-node circle {
+  fill: rgb(0, 24, 168);
+}
+
+.descendant-of-pinning-node-node text {
+}
+
+.descendant-of-pinning-node-branch {
+  stroke: rgb(0, 24, 168);
+}
+
+/*
+ * Create a table class for a fixed size body.
+ * Based on https://stackoverflow.com/a/23518856/27310
+ */
+.table-fixed-height {
+}
+
+.table-fixed-height thead {
+    display: block;
+    width: 100%;
+}
+
+.table-fixed-height tbody {
+    display: block;
+    width: 100%;
+    height: 15em;
+    overflow-y: scroll;
+    z-index: -1;
+}
+
+.table-fixed-height tr {
+    width: 100%;
+    display: inline-table;
+    table-layout: fixed;
+}
+
+/*
+ * The following code is stolen from Bootstrap 3.3, which is a Phylotree.js
+ * dependency. Since we otherwise use Bootstrap 4+, we need to override this
+ * here so the menu works.
+ *
+ * We apply it only to subclasses of #d3_layout_phylotree_context_menu to limit
+ * their fallout on other elements.
+ */
+#d3_layout_phylotree_context_menu.dropdown-menu {
+ position: absolute;
+ top: 100%;
+ left: 0;
+ z-index: 1000;
+ display: none;
+ float: left;
+ min-width: 160px;
+ padding: 5px 0;
+ margin: 2px 0 0;
+ font-size: 14px;
+ text-align: left;
+ list-style: none;
+ background-color: #fff;
+ -webkit-background-clip: padding-box;
+         background-clip: padding-box;
+ border: 1px solid #ccc;
+ border: 1px solid rgba(0, 0, 0, .15);
+ border-radius: 4px;
+ -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+         box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+}
+#d3_layout_phylotree_context_menu.dropdown-menu.pull-right {
+ right: 0;
+ left: auto;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu .divider {
+ height: 1px;
+ margin: 9px 0;
+ overflow: hidden;
+ background-color: #e5e5e5;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu > li > a {
+ display: block;
+ padding: 3px 20px;
+ clear: both;
+ font-weight: normal;
+ line-height: 1.42857143;
+ color: #333;
+ white-space: nowrap;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu > li > a:hover,
+#d3_layout_phylotree_context_menu.dropdown-menu > li > a:focus {
+ color: #262626;
+ text-decoration: none;
+ background-color: #f5f5f5;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu > .active > a,
+#d3_layout_phylotree_context_menu.dropdown-menu > .active > a:hover,
+#d3_layout_phylotree_context_menu.dropdown-menu > .active > a:focus {
+ color: #fff;
+ text-decoration: none;
+ background-color: #337ab7;
+ outline: 0;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a,
+#d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:hover,
+#d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:focus {
+ color: #777;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:hover,
+#d3_layout_phylotree_context_menu.dropdown-menu > .disabled > a:focus {
+ text-decoration: none;
+ cursor: not-allowed;
+ background-color: transparent;
+ background-image: none;
+ filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.open > #d3_layout_phylotree_context_menu.dropdown-menu {
+ display: block;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu-right {
+ right: 0;
+ left: auto;
+}
+#d3_layout_phylotree_context_menu.dropdown-menu-left {
+ right: auto;
+ left: 0;
+}
+#d3_layout_phylotree_context_menu.dropdown-header {
+ display: block;
+ padding: 3px 20px;
+ font-size: 12px;
+ line-height: 1.42857143;
+ color: #777;
+ white-space: nowrap;
+}
+#d3_layout_phylotree_context_menu.dropdown-backdrop {
+ position: fixed;
+ top: 0;
+ right: 0;
+ bottom: 0;
+ left: 0;
+ z-index: 990;
+}
+
+</style>

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -70,12 +70,24 @@ export default {
     },
     newickAsString() {
       // Returns the Newick string of this phylogeny.
-      return this.phylogeny.newick || '()';
+      return this.newick;
+    },
+    phylogeny() {
+      // TODO fix hack
+      return { newick: this.newick };
+    baseURIForPhylogeny() {
+      return `http://example.org/#phylogeny${this.phylogenyIndex}`;
     },
     parsedNewick() {
-      return new PhylogenyWrapper(this.phylogeny).getParsedNewickWithIRIs(
-        this.$store.getters.getBaseURIForPhylogeny(this.phylogeny),
-        d3.layout.newick_parser,
+      if (has(window, 'd3') && has(d3, 'layout') && has(d3.layout, 'newick_parser')) {
+        return new PhylogenyWrapper({ newick: this.newick }).getParsedNewickWithIRIs(
+          this.baseURIForPhylogeny,
+          d3.layout.newick_parser,
+        );
+      }
+
+      return new PhylogenyWrapper({ newick: this.newick }).getParsedNewickWithIRIs(
+        this.baseURIForPhylogeny
       );
     },
     newickErrors() {
@@ -282,17 +294,22 @@ export default {
       this.pinningNodes = [];
       this.pinningNodeChildrenIRIs = new Set();
 
-      // Draw the tree.
-      this.tree
-        .size([
-          // height
-          0,
-          // width
-          $(`#phylogeny${this.phylogenyIndex}`).width() - 40,
-          // We need more space because our fonts are bigger than the default.
-        ])
-        .spacing_x(this.spacingX)
-        .update();
+      // Do we have a tree?
+      const tree = this.tree;
+
+      if (tree !== undefined) {
+        // Draw the tree.
+        this.tree
+          .size([
+            // height
+            0,
+            // width
+            $(`#phylogeny${this.phylogenyIndex}`).width() - 40,
+            // We need more space because our fonts are bigger than the default.
+          ])
+          .spacing_x(this.spacingX)
+          .update();
+      }
     },
   },
 };

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -58,6 +58,10 @@ export default {
       type: String,
       default: uniqueId(),
     },
+    reasoningResults: {
+      type: Object,
+      default: () => { return {}; },
+    },
   },
   data() {
     return {
@@ -69,17 +73,6 @@ export default {
     };
   },
   computed: {
-    reasoningResults() {
-      // Included so we can watch this for changes, see `watch` below.
-      return this.$store.state.phyx.reasoningResults;
-    },
-    newickAsString() {
-      // Returns the Newick string of this phylogeny.
-      return this.newick;
-    },
-    phylogeny() {
-      // TODO fix hack
-      return { newick: this.newick };
     baseURIForPhylogeny() {
       return `http://example.org/#phylogeny${this.phylogenyIndex}`;
     },
@@ -137,7 +130,7 @@ export default {
             // selected phyloreference, add an 'id' so we can jump to it
             // and a CSS class to render it differently from other labels.
             if (
-              this.$store.getters.getExpectedNodeLabelsOnPhylogeny(this.phylogeny, this.phyloref).includes(data.name)
+              this.$store.getters.getExpectedNodeLabelsOnPhylogeny({newick: this.newick}, this.phyloref).includes(data.name)
             ) {
               textLabel.attr('id', `current_expected_label_phylogeny_${this.phylogenyIndex}`);
               textLabel.classed('selected-internal-label', true);
@@ -251,8 +244,8 @@ export default {
       // If reasoning occurs, we'll need to redraw this tree.
       this.redrawTree();
     },
-    phylogeny() {
-      // If the phylogeny changed, redraw the tree.
+    newick() {
+      // If the Newick changes, redraw the tree.
       this.redrawTree();
     },
   },

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -34,6 +34,11 @@
 
 import { uniqueId, has } from 'lodash';
 import { PhylogenyWrapper } from '@phyloref/phyx';
+import Vue from 'vue';
+import { ResizeObserver } from 'vue-resize';
+
+// Set up ResizeObserver.
+Vue.component('ResizeObserver', ResizeObserver);
 
 /*
  * Note that this requires the Phylotree Javascript to be loaded in the HTML

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -93,6 +93,9 @@ export default {
       return errors.filter(error => error.title !== 'No phylogeny entered');
     },
     tree() {
+      // Is Phylotree actually loaded? If not, bail out.
+      if (!has(window, 'd3') || !has(d3, 'layout') || !has(d3.layout, 'phylotree')) return;
+
       // Set up Phylotree.
       const tree = d3.layout.phylotree()
         .svg(d3.select(`#phylogeny${this.phylogenyIndex}`))

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -53,23 +53,25 @@ export default {
     },
     baseURIForPhylogeny: {
       type: String,
-      default: `http://example.org/#phylogeny${this.phylogenyIndex}`,
     },
   },
   computed: {
+    baseURIForPhylogenyComputed() {
+      return this.baseURIForPhylogeny || `http://example.org/#phylogeny${this.phylogenyIndex}`;
+    },
     parsedNewick() {
       // Return a tree-like structure that represents a Newick string. Phylotree.js
       // is loaded,we use d3.layout.newick_parser; otherwise, we use the default
       // parser used by PhylogenyWrapper.
       if (has(window, 'd3') && has(window.d3, 'layout') && has(window.d3.layout, 'newick_parser')) {
         return new PhylogenyWrapper({ newick: this.newick }).getParsedNewickWithIRIs(
-          this.baseURIForPhylogeny,
+          this.baseURIForPhylogenyComputed,
           window.d3.layout.newick_parser,
         );
       }
 
       return new PhylogenyWrapper({ newick: this.newick }).getParsedNewickWithIRIs(
-        this.baseURIForPhylogeny
+        this.baseURIForPhylogenyComputed
       );
     },
     newickErrors() {

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -52,19 +52,6 @@ export default {
       type: String,
       default: uniqueId(),
     },
-    reasoningResults: {
-      type: Object,
-      default: () => { return {}; },
-    },
-  },
-  data() {
-    return {
-      // List of pinning nodes to highlight for a particular phylogeny.
-      pinningNodes: [],
-      // List of pinning nodes and all their children, so the entire clade can be
-      // highlighted as needed.
-      pinningNodeChildrenIRIs: new Set(),
-    };
   },
   computed: {
     phylogeny() {
@@ -127,16 +114,6 @@ export default {
             }
           }
 
-          // Maybe this isn't a pinning node, but it is a child of a pinning node.
-          if (
-            has(data, '@id')
-            && this.pinningNodeChildrenIRIs.has(data['@id'])
-          ) {
-            // Apply a class.
-            // Note that this applies to the resolved-node too.
-            element.classed('descendant-of-pinning-node-node', true);
-          }
-
           if (data.name !== undefined && data.children === undefined) {
             // Labeled leaf node! Look for taxonomic units.
             const tunits = TaxonomicUnitWrapper.getTaxonomicUnitsFromNodeLabel(data.name);
@@ -145,30 +122,12 @@ export default {
               element.classed('terminal-node-without-tunits', true);
             }
           }
-        })
-        .style_edges((element, data) => {
-          // Is the parent a descendant of a pinning node? If so, we need to
-          // select this branch!
-          if (
-            has(data, 'source')
-            && has(data.source, '@id')
-            && this.pinningNodeChildrenIRIs.has(data.source['@id'])
-          ) {
-            // Apply a class to this branch.
-            element.classed('descendant-of-pinning-node-branch', true);
-          } else {
-            element.classed('descendant-of-pinning-node-branch', false);
-          }
         });
       tree(this.parsedNewick);
       return tree;
     },
   },
   watch: {
-    reasoningResults() {
-      // If reasoning occurs, we'll need to redraw this tree.
-      this.redrawTree();
-    },
     newick() {
       // If the Newick changes, redraw the tree.
       this.redrawTree();
@@ -213,10 +172,6 @@ export default {
       return nextID;
     },
     redrawTree() {
-      // Reset the pinning node information before redrawing.
-      this.pinningNodes = [];
-      this.pinningNodeChildrenIRIs = new Set();
-
       // Do we have a tree?
       const tree = this.tree;
 
@@ -286,44 +241,6 @@ export default {
 
 /* Node label for a terminal node without taxonomic units */
 .terminal-node-without-tunits {
-}
-
-/* The selected internal label on a phylogeny, whether determined to be the pinning node or not. */
-.selected-internal-label {
-    font-size: 16pt;
-    fill: rgb(0, 24, 168);
-}
-
-/*
- * An additional class for nodes that are the pinning node. When the phyloreference
- * resolves to a single terminal node, it will be laid out in this way, rather
- * than as an .internal-specifier-node.
- */
-.pinning-node text {
-    font-weight: bolder;
-}
-
-/*
- * The descendant-of-pinning-node class instructions below apply to the entire resolved node,
- * which includes the circle as well as the text label. We want to coordinate
- * colours between:
- *  - The circle that appears next to the node label,
- *  - The node label, whether internal or terminal, and
- *  - The branches descending from the pinning node.
- *
- * Note that .internal-specifier-node is set up to override this formatting, so
- * internal node labels will be formatted differently from other terminals
- * descending from the pinning node.
- */
-.descendant-of-pinning-node-node circle {
-  fill: rgb(0, 24, 168);
-}
-
-.descendant-of-pinning-node-node text {
-}
-
-.descendant-of-pinning-node-branch {
-  stroke: rgb(0, 24, 168);
 }
 
 /*

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -2,7 +2,7 @@
   <div>
     <template v-if="newickErrors.length > 0">
       <template v-for="(error, errorIndex) of newickErrors">
-        <p><strong>{{ error.title }}.</strong> {{ error.message }}</p>
+        <p :key="errorIndex"><strong>{{ error.title }}.</strong> {{ error.message }}</p>
       </template>
     </template>
     <div
@@ -30,6 +30,7 @@
 import { uniqueId, has } from 'lodash';
 import { PhylogenyWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
 import Vue from 'vue';
+import jQuery from 'jquery';
 import { ResizeObserver } from 'vue-resize';
 
 // Set up ResizeObserver so we can redraw the tree if the window is resized.
@@ -52,7 +53,7 @@ export default {
     },
     baseURIForPhylogeny: {
       type: String,
-      default: () => `http://example.org/#phylogeny${this.phylogenyIndex}`,
+      default: `http://example.org/#phylogeny${this.phylogenyIndex}`,
     },
   },
   computed: {
@@ -60,10 +61,10 @@ export default {
       // Return a tree-like structure that represents a Newick string. Phylotree.js
       // is loaded,we use d3.layout.newick_parser; otherwise, we use the default
       // parser used by PhylogenyWrapper.
-      if (has(window, 'd3') && has(d3, 'layout') && has(d3.layout, 'newick_parser')) {
+      if (has(window, 'd3') && has(window.d3, 'layout') && has(window.d3.layout, 'newick_parser')) {
         return new PhylogenyWrapper({ newick: this.newick }).getParsedNewickWithIRIs(
           this.baseURIForPhylogeny,
-          d3.layout.newick_parser,
+          window.d3.layout.newick_parser,
         );
       }
 
@@ -83,11 +84,11 @@ export default {
       // Set up Phylotree.js.
 
       // Is Phylotree actually loaded? If not, bail out.
-      if (!has(window, 'd3') || !has(d3, 'layout') || !has(d3.layout, 'phylotree')) return;
+      if (!has(window, 'd3') || !has(window.d3, 'layout') || !has(window.d3.layout, 'phylotree')) return;
 
       // Set up Phylotree.
-      const tree = d3.layout.phylotree()
-        .svg(d3.select(`#phylogeny${this.phylogenyIndex}`))
+      const tree = window.d3.layout.phylotree()
+        .svg(window.d3.select(`#phylogeny${this.phylogenyIndex}`))
         .options({
           'internal-names': true,
           transitions: false,
@@ -141,7 +142,7 @@ export default {
             // height
             0,
             // width
-            $(`#phylogeny${this.phylogenyIndex}`).width() - 40,
+            jQuery(`#phylogeny${this.phylogenyIndex}`).width() - 40,
             // We need more space because our fonts are bigger than the default.
           ])
           .spacing_x(this.spacingX)

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -39,6 +39,7 @@ Vue.component('ResizeObserver', ResizeObserver);
 export default {
   name: 'Phylotree',
   props: {
+    // Properties
     newick: { // The Newick string of the phylogeny to display.
       type: String,
       default: '()',
@@ -53,6 +54,12 @@ export default {
     },
     baseURIForPhylogeny: {
       type: String,
+    },
+
+    // Configuration
+    displayInternalNodes: { // Flag for whether to display internal node labels
+      type: Boolean,
+      default: false,
     },
   },
   computed: {
@@ -108,7 +115,7 @@ export default {
           if (has(data, 'name') && data.name !== '' && data.children) {
             // If the node has a label and has children (i.e. is an internal node),
             // we display it next to the node by creating a new 'text' element.
-            if (textLabel.empty()) {
+            if (this.displayInternalNodes && textLabel.empty()) {
               textLabel = element.append('text');
 
               // Place internal label to the left of the root node.

--- a/src/components/phylogeny/Phylotree.vue
+++ b/src/components/phylogeny/Phylotree.vue
@@ -10,8 +10,8 @@
       class="phylotreeContainer"
     >
       <svg
-        :id="'phylogeny' + phylogenyIndex"
         class="col-md-12 phylogeny"
+        :id="'phylogeny_' + phylogenyIndex"
       />
       <ResizeObserver @notify="redrawTree()" />
     </div>
@@ -90,7 +90,7 @@ export default {
 
       // Set up Phylotree.
       const tree = window.d3.layout.phylotree()
-        .svg(window.d3.select(`#phylogeny${this.phylogenyIndex}`))
+        .svg(window.d3.select(`#phylogeny_${this.phylogenyIndex}`))
         .options({
           'internal-names': true,
           transitions: false,
@@ -144,7 +144,7 @@ export default {
             // height
             0,
             // width
-            jQuery(`#phylogeny${this.phylogenyIndex}`).width() - 40,
+            jQuery(`#phylogeny_${this.phylogenyIndex}`).width(),
             // We need more space because our fonts are bigger than the default.
           ])
           .spacing_x(this.spacingX)


### PR DESCRIPTION
This PR adds functionality for downloading Open Tree Taxonomy IDs for all currently loaded specifiers, and then to download the Open Tree induced subtree for all these Open Tree Taxonomy IDs. It also uses Phylotree.js to display the induced subtree.

Should be merged after PR #3.