### PR TITLE
UI improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -412,11 +412,9 @@ export default {
       );
 
       phylorefsWithEquivalentClass.forEach(phyloref => {
-        if(has(phyloref, 'label')) {
-          if(!has(phyloref, '@id')) {
-            phyloref['@id'] = this.ONTOLOGY_BASEURI + 'phyloref_' + uniqueId();
-          }
-        }
+        // Note that multiple files might have overlapping '@id's.
+        // To avoid confusion, we re-@id all the phylorefs.
+        phyloref['@id'] = this.ONTOLOGY_BASEURI + 'phyloref_' + uniqueId();
 
         // Every entity in the JSON-LD needs a '@context', so here is the one for this phyloref.
         if(!has(phyloref, '@context')) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -511,8 +511,8 @@ export default {
         },
       ];
 
-      return JSON.stringify(ontologyHeader.concat(phylorefsWithEquivalentClass).concat(phylogenyNodes), null, 4);
-    }
+      return JSON.stringify(ontologyHeader.concat(phylorefsWithEquivalentClass).concat(phylogenyNodes), undefined, 4);
+    },
 
     downloadAsJSONLD() {
       // Download a copy of the current ontology (to be reasoned over) as JSON-LD.

--- a/src/App.vue
+++ b/src/App.vue
@@ -512,7 +512,11 @@ export default {
         },
       ];
 
-      return JSON.stringify(ontologyHeader.concat(phylorefsWithEquivalentClass).concat(phylogenyNodes), undefined, 4);
+      return JSON.stringify(
+        ontologyHeader.concat(phylorefsWithEquivalentClass).concat(phylogenyNodes),
+        null,
+        4
+      );
     },
 
     downloadAsJSONLD() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -129,6 +129,14 @@
             >
               Reason over phylogeny <span v-if="reasoningInProgress"><em>(in progress)</em></span>
             </button>
+
+            <button
+              class="btn btn-secondary"
+              href="javascript:;"
+              @click="downloadAsJSONLD()"
+            >
+              Download as ontology
+            </button>
           </div>
         </div>
       </div>
@@ -152,6 +160,7 @@ import jQuery from 'jquery';
 import { PhylogenyWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
 import Vue from 'vue';
 import { signer } from 'x-hub-signature';
+import { saveAs } from 'filesaver.js-npm';
 
 // Navigation controls.
 import TopNavigationBar from './components/TopNavigationBar.vue';
@@ -503,6 +512,15 @@ export default {
       ];
 
       return JSON.stringify(ontologyHeader.concat(phylorefsWithEquivalentClass).concat(phylogenyNodes), null, 4);
+    }
+
+    downloadAsJSONLD() {
+      // Download a copy of the current ontology (to be reasoned over) as JSON-LD.
+      const content = [this.getPhylorefsAndPhylogenyAsOntology()];
+
+      // Save to local hard drive.
+      const jsonldFile = new File(content, 'download.jsonld', { type: 'application/json;charset=utf-8' });
+      saveAs(jsonldFile);
     },
 
     reasonOverPhylogeny() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -86,9 +86,10 @@
                 <template v-for="(ottId, index) of unknownOttIds">
                   <a
                     target="_blank"
+                    :key="'unknownOttIds_a_' + ottId"
                     :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + ottId.substring(3)"
                   >{{ottId}}</a>
-                  <span v-if="index+1 < unknownOttIds.length" class="pr-1">,</span>
+                  <span :key="'unknownOttIds_span_' + ottId" v-if="index+1 < unknownOttIds.length" class="pr-1">,</span>
                 </template>
               </div>
             </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
             :ottInfoBySpecifierLabel="ottInfoBySpecifierLabel"
             :reasoningResults="reasoningResults"
             :nodesByID="nodesByID"
+            :unknownOttIdReasons="unknownOttIdReasons"
           />
         </div>
         <div class="card-footer">
@@ -74,6 +75,23 @@
                 />
               </div>
             </div>
+            <div class="form-group row" v-if="unknownOttIds.length > 0">
+              <label
+                for="newick"
+                class="col-md-2 control-label"
+              >
+                Taxa with Open Tree IDs but not on the synthetic tree
+              </label>
+              <div class="col-md-10 input-group">
+                <template v-for="(ottId, index) of unknownOttIds">
+                  <a
+                    target="_blank"
+                    :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + ottId.substring(3)"
+                  >{{ottId}}</a>
+                  <span v-if="index+1 < unknownOttIds.length" class="pr-1">,</span>
+                </template>
+              </div>
+            </div>
           </form>
         </div>
         <div class="card-footer">
@@ -129,7 +147,7 @@
  *  - downloading the induced subtree for the set of all OTT ids
  */
 
-import { has, isEqual, chunk, uniq, uniqueId, isString } from 'lodash';
+import { has, isEqual, chunk, uniq, uniqueId, isString, keys } from 'lodash';
 import jQuery from 'jquery';
 import { PhylogenyWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
 import Vue from 'vue';
@@ -174,6 +192,10 @@ export default {
 
     // Is reasoning currently in progress?
     reasoningInProgress: false,
+
+    // List of unknown OTT Ids, if any.
+    unknownOttIds: [],
+    unknownOttIdReasons: {},
 
     // URL to Phyx context JSON.
     PHYX_CONTEXT_JSON: "http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json",
@@ -280,6 +302,10 @@ export default {
 
       if(ottIds.length === 0) return;
 
+      // Reset the unknown OTT Ids.
+      this.unknownOttIds = [];
+      this.unknownOttIdReasons = {};
+
       // Query the induced subtree, i.e. a tree showing the relationships between all
       // these OTT ids.
       jQuery.ajax({
@@ -299,11 +325,13 @@ export default {
           // will return a list of nodes that could not be matched. We can remove
           // these OTT ids from our list of queries and trying again.
           if(x.responseJSON.message === "[/v3/tree_of_life/induced_subtree] Error: Nodes not found!") {
-            const unknownOttIds = x.responseJSON.unknown;
-            console.log("The Open Tree synthetic tree does not contain the following nodes: ", unknownOttIds);
+            const unknownOttIdReasons = x.responseJSON.unknown;
+            console.log("The Open Tree synthetic tree does not contain the following nodes: ", unknownOttIdReasons);
+            this.unknownOttIdReasons = unknownOttIdReasons;
+            this.unknownOttIds = keys(unknownOttIdReasons);
 
             // Remove the unknown OTT ids from the list of OTT ids to be queried.
-            const knownOttIds = ottIds.filter(id => !has(unknownOttIds, "ott" + id));
+            const knownOttIds = ottIds.filter(id => !has(unknownOttIdReasons, "ott" + id));
             console.log("Query has been reduced to the following nodes: ", knownOttIds);
 
             // Redo query without unknown OTT Ids.

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,7 +22,7 @@
               href="javascript:;"
               onclick="$('#load-jsonld').trigger('click')"
             >
-              Add phyloreferences from JSON-LD file
+              Import from ontology in JSON-LD
             </button>
             <input
               id="load-jsonld"

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -202,6 +202,7 @@ export default {
       // Return a string describing this specifier with HTML elements to format
       // particular elements, such as italicizing the scientific name.
       const label = new TaxonomicUnitWrapper(specifier).label;
+      if(!label) return "(could not read)";
       if(label.startsWith("Specimen")) return label;
 
       return label.replace(/^\w+ [a-z-]+/, "<em>$&</em>");

--- a/src/components/PhylorefTable.vue
+++ b/src/components/PhylorefTable.vue
@@ -60,6 +60,9 @@
                     target="_blank"
                     :href="'https://tree.opentreeoflife.org/taxonomy/browse?id=' + getOTTId(specifier)"
                   >ott</a>)
+                  <span v-if="unknownOttIdReasons['ott' + getOTTId(specifier)]">
+                    <br>Not in synthetic tree: {{unknownOttIdReasons['ott' + getOTTId(specifier)]}}
+                  </span>
                 </template>
               </td>
             </tr>
@@ -98,6 +101,10 @@ export default {
       default: () => { return {}; },
     },
     nodesByID: {
+      type: Object,
+      default: () => { return {}; },
+    },
+    unknownOttIdReasons: {
       type: Object,
       default: () => { return {}; },
     },


### PR DESCRIPTION
This PR improves the Open Tree of Life Resolver user interface in several ways:
 - Reports Open Tree Taxonomy IDs that are not present on the synthetic tree.
 - Adds a "Download as ontology" button to download the current ontology in JSON-LD for debugging.
 - Attempt to improve responsiveness by trying to add "(in progress)" to the "Reason over phylogeny" as soon as possible.

This should be merged after PR #10 has been merged.