### PR TITLE
Gzip JSON-LD file before uploading to server to save time

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -162,6 +162,7 @@ import { PhylogenyWrapper, TaxonomicUnitWrapper } from '@phyloref/phyx';
 import Vue from 'vue';
 import { signer } from 'x-hub-signature';
 import { saveAs } from 'filesaver.js-npm';
+import zlib from 'zlib';
 
 // Navigation controls.
 import TopNavigationBar from './components/TopNavigationBar.vue';
@@ -544,7 +545,7 @@ export default {
       Vue.nextTick(function () {
         // Prepare request for submission.
         const query = jQuery.param({
-          jsonld: outerThis.getPhylorefsAndPhylogenyAsOntology(),
+          jsonldGzipped: Buffer.from(zlib.gzipSync(outerThis.getPhylorefsAndPhylogenyAsOntology())).toString('base64')
         }).replace(/%20/g, '+');  // $.post will do this automatically,
                                   // but we need to do this here so our
                                   // signature works.

--- a/src/App.vue
+++ b/src/App.vue
@@ -543,9 +543,14 @@ export default {
       // file into JSON-LD.
       const outerThis = this;
       Vue.nextTick(function () {
+        // Convert phylorefs and phylogeny to JSON-LD.
+        const jsonld = outerThis.getPhylorefsAndPhylogenyAsOntology();
+        const jsonldGzipped = zlib.gzipSync(jsonld);
+
         // Prepare request for submission.
         const query = jQuery.param({
-          jsonldGzipped: Buffer.from(zlib.gzipSync(outerThis.getPhylorefsAndPhylogenyAsOntology())).toString('base64')
+          // Convert Gzipped data into a string in Base64.
+          jsonldGzipped: Buffer.from(jsonldGzipped).toString('base64')
         }).replace(/%20/g, '+');  // $.post will do this automatically,
                                   // but we need to do this here so our
                                   // signature works.


### PR DESCRIPTION
When trying to host JPhyloRef on my own server, I found that files were being uploaded too slowly. This PR updates the Open Tree Resolver so that it uploads the file as a Gzipped string to save time. Requires a JPhyloRef that supports phyloref/jphyloref#63.