### PR TITLE
Updated JPhyloRef submission URL to reasoner.phyloref.org

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // URL to submit reasoning requests to.
-  JPHYLOREF_SUBMISSION_URL: 'http://phyloref.ggvaidya.com/reason',
+  JPHYLOREF_SUBMISSION_URL: 'http://reasoner.phyloref.org/reason',
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // URL to submit reasoning requests to.
-  JPHYLOREF_SUBMISSION_URL: 'https://phyloref.rc.ufl.edu/hooks/reason',
+  JPHYLOREF_SUBMISSION_URL: 'http://phyloref.ggvaidya.com/reason',
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',


### PR DESCRIPTION
Since our backend server hosted at UF is temporarily down, this PR changes that to my server at reasoner.phyloref.org for now. We'll revert it to UF once it's working again.

This should be merged after #16 has been merged.