### PR TITLE
Updated JPhyloRef submission URL to use HTTPS

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // URL to submit reasoning requests to.
-  JPHYLOREF_SUBMISSION_URL: 'http://reasoner.phyloref.org/reason',
+  JPHYLOREF_SUBMISSION_URL: 'https://reasoner.phyloref.org/reason',
 
   // X-Hub-Signature secret used to communicate with JPhyloRef.
   JPHYLOREF_X_HUB_SIGNATURE_SECRET: 'undefined',


### PR DESCRIPTION
This PR updates the JPhyloRef submission URL to HTTPS, i.e. https://reasoner.phyloref.org/version. The plan going forward is to leave this URL unchanged in the configuration, and to modify the DNS settings of that domain so that it points to an HTTPS server capable of reasoning over phyloreferences.