### PR TITLE
Cleaned up version string and URL in the top navigation panel

### DIFF
--- a/src/components/TopNavigationBar.vue
+++ b/src/components/TopNavigationBar.vue
@@ -2,12 +2,8 @@
   <div>
     <!-- Navigation bar at the top of the page -->
     <nav class="navbar navbar-expand navbar-dark bg-dark mb-2 fixed-top">
-      <a
-        class="navbar-brand"
-        href="index.html"
-      >
-        Open Tree Resolver <small>{{ version }}</small>
-      </a>
+      <a class="navbar-brand" href="./index.html" style="margin-right: 0.2em;">Open Tree Resolver</a>
+      <a class="navbar-brand" :href="versionURL" target="_blank"><small>{{ versionString }}</small></a>
       <div class="collapse navbar-collapse">
         <ul class="navbar-nav">
           <li class="nav-item">
@@ -61,8 +57,23 @@ export default {
   props: {
     version: {
       type: String,
-      default: 'unversioned',
     },
   },
+  computed: {
+    versionString() {
+      if (!this.version) return "";
+      if (this.version.startsWith("refs/tags/")) {
+        return this.version.substr(10);
+      }
+      return this.version;
+    },
+    versionURL() {
+      if (!this.version) return undefined;
+      if (this.version.startsWith("refs/tags/")) {
+        return "https://github.com/phyloref/open-tree-resolver/releases/tag/" + this.version.substr(10);
+      }
+      return undefined;
+    }
+  }
 };
 </script>


### PR DESCRIPTION
This PR cleans up the version string in the top navigation panel by removing the `refs/tags/` part of the version string. It also turns the version into a link to the tag in the repository.